### PR TITLE
Report error status

### DIFF
--- a/client.go
+++ b/client.go
@@ -98,6 +98,7 @@ func (c *Client) doRequest(r *http.Request) (*http.Response, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		return nil, NewHTTPError(resp)
@@ -107,7 +108,6 @@ func (c *Client) doRequest(r *http.Request) (*http.Response, error) {
 
 	// We read and save the response body so that if we don't have error messages
 	// we can set it again for future usage
-	defer resp.Body.Close()
 	b, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err

--- a/client_test.go
+++ b/client_test.go
@@ -101,7 +101,38 @@ func TestClient_doRequest_WithHTTPErrors(t *testing.T) {
 
 	_, err = c.doRequest(req)
 	require.NotNil(err)
-	assert.IsType(&httpError{}, err)
+	httpErr, ok := err.(*HTTPError)
+	assert.True(ok)
+	assert.Equal(500, httpErr.StatusCode)
+	assert.Equal("", httpErr.Status)
+	assert.Equal("", httpErr.Message)
+	assert.Equal(0, httpErr.ErrorNo)
+}
+
+func TestClient_doRequest_WithHTTPErrorsMessage(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	c, err := New(Auth{Username: "random-user", Apikey: "my-pass"})
+	require.Nil(err)
+
+	hc := &fakeHTTPClient{
+		StatusCode: 400,
+		Fixture:    "bad_request.json",
+	}
+	c.c = hc
+
+	req, err := http.NewRequest("GET", "http://example.com/test", nil)
+	require.Nil(err)
+
+	_, err = c.doRequest(req)
+	require.NotNil(err)
+	httpErr, ok := err.(*HTTPError)
+	assert.True(ok)
+	assert.Equal(400, httpErr.StatusCode)
+	assert.Equal("", httpErr.Status)
+	assert.Equal("Something bad happened.", httpErr.Message)
+	assert.Equal(42, httpErr.ErrorNo)
 }
 
 func TestClient_doRequest_HttpAuthenticationErrors(t *testing.T) {

--- a/cmd/statuscake/main.go
+++ b/cmd/statuscake/main.go
@@ -6,8 +6,9 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/DreamItGetIT/statuscake"
 	"strings"
+
+	"github.com/manifoldco/statuscake"
 )
 
 var log *logpkg.Logger

--- a/errors.go
+++ b/errors.go
@@ -41,7 +41,6 @@ func NewHTTPError(r *http.Response) *HTTPError {
 	httpError.StatusCode = r.StatusCode
 
 	// Attempt to read the body to find the error message.  Return if no body exists.
-	defer r.Body.Close()
 	b, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		return &httpError

--- a/errors.go
+++ b/errors.go
@@ -41,6 +41,7 @@ func NewHTTPError(r *http.Response) *HTTPError {
 	httpError.StatusCode = r.StatusCode
 
 	// Attempt to read the body to find the error message.  Return if no body exists.
+	defer r.Body.Close()
 	b, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		return &httpError

--- a/fixtures/bad_request.json
+++ b/fixtures/bad_request.json
@@ -1,0 +1,4 @@
+{
+    "ErrNo": 42,
+    "Error": "Something bad happened."
+}

--- a/tests.go
+++ b/tests.go
@@ -112,6 +112,9 @@ type Test struct {
 
 	// Use to specify whether redirects should be followed
 	FollowRedirect bool `json:"FollowRedirect" querystring:"FollowRedirect"`
+
+	// HTTP Tests only. If enabled, tests will send warnings if the SSL certificate is about to expire. Paid users only
+	EnableSSLAlert bool `json:"EnableSSLAlert" querystring:"EnableSSLAlert"`
 }
 
 // Validate checks if the Test is valid. If it's invalid, it returns a ValidationError with all invalid fields. It returns nil otherwise.

--- a/tests_test.go
+++ b/tests_test.go
@@ -97,6 +97,7 @@ func TestTest_ToURLValues(t *testing.T) {
 		TestTags:       []string{"tag1", "tag2"},
 		StatusCodes:    "500",
 		FollowRedirect: false,
+		EnableSSLAlert: true,
 	}
 
 	expected := url.Values{
@@ -130,6 +131,7 @@ func TestTest_ToURLValues(t *testing.T) {
 		"PostRaw":        {""},
 		"FinalEndpoint":  {""},
 		"FollowRedirect": {"0"},
+		"EnableSSLAlert": {"1"},
 	}
 
 	assert.Equal(expected, test.ToURLValues())
@@ -177,7 +179,7 @@ func TestTests_All(t *testing.T) {
 		Status:        "Down",
 		Uptime:        0,
 		NodeLocations: []string{"foo"},
-		TestTags:  	   []string{"test1", "test2"},
+		TestTags:      []string{"test1", "test2"},
 	}
 	assert.Equal(expectedTest, tests[1])
 }
@@ -210,7 +212,7 @@ func TestTests_AllWithFilter(t *testing.T) {
 		Status:        "Down",
 		Uptime:        0,
 		NodeLocations: []string{"foo"},
-		TestTags:  	   []string{"test1", "test2"},
+		TestTags:      []string{"test1", "test2"},
 	}
 	assert.Equal(expectedTest, tests[0])
 }


### PR DESCRIPTION
This PR updates the error object so that helpful message is returned and also someone using this library can make decisions based on the error message or the status code. 

Also added `EnableSSLAlert` option to `Tests`